### PR TITLE
Remove composer install command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
     - COMPOSER_FLAGS="--prefer-lowest"
 
 script:
-  - composer install
   - composer update
   - phpunit --coverage-text --coverage-clover=coverage.clover
 


### PR DESCRIPTION
# Changed log

- The `composer 2.0` version has been released, it should use `composer update` command when the `composer.lock` file is not found. And the related warning message is as follows:

```
No lock file found. Updating dependencies instead of installing from lock file. Use composer update over composer install if you do not have a lock file.
```